### PR TITLE
D-040: test: parametrise make_symbol helper by line range

### DIFF
--- a/tests/context.rs
+++ b/tests/context.rs
@@ -11,34 +11,14 @@ use commitbee::domain::{
     ChangeStatus, CodeSymbol, CommitType, FileCategory, IntentKind, SymbolKind,
 };
 use commitbee::services::context::ContextBuilder;
-use helpers::{make_file_change, make_renamed_file, make_staged_changes};
+use helpers::{
+    make_file_change, make_renamed_file, make_staged_changes, make_symbol, make_symbol_at,
+};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 fn default_config() -> Config {
     Config::default()
-}
-
-fn make_symbol(
-    name: &str,
-    kind: SymbolKind,
-    file: &str,
-    is_public: bool,
-    is_added: bool,
-) -> CodeSymbol {
-    CodeSymbol {
-        kind,
-        name: name.to_string(),
-        file: PathBuf::from(file),
-        line: 1,
-        end_line: 10,
-        is_public,
-        is_added,
-        is_whitespace_only: None,
-        span_change_kind: None,
-        signature: None,
-        parent_scope: None,
-    }
 }
 
 // ─── CommitType inference ─────────────────────────────────────────────────────
@@ -2058,4 +2038,31 @@ fn intents_capped_at_three() {
         "intents should be capped at 3, got {}",
         ctx.intents.len()
     );
+}
+
+// ─── make_symbol helper smoke tests ──────────────────────────────────────────
+
+#[test]
+fn make_symbol_defaults_to_lines_1_through_10() {
+    let sym = make_symbol("foo", SymbolKind::Function, "src/lib.rs", true, true);
+    assert_eq!(sym.line, 1);
+    assert_eq!(sym.end_line, 10);
+}
+
+#[test]
+fn make_symbol_at_pins_arbitrary_line_range() {
+    let sym = make_symbol_at(
+        "bar",
+        SymbolKind::Function,
+        "src/lib.rs",
+        false,
+        true,
+        42,
+        57,
+    );
+    assert_eq!(sym.line, 42);
+    assert_eq!(sym.end_line, 57);
+    assert_eq!(sym.name, "bar");
+    assert!(!sym.is_public);
+    assert!(sym.is_added);
 }

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -5,7 +5,9 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use commitbee::domain::{ChangeStatus, DiffStats, FileCategory, FileChange, StagedChanges};
+use commitbee::domain::{
+    ChangeStatus, CodeSymbol, DiffStats, FileCategory, FileChange, StagedChanges, SymbolKind,
+};
 
 /// Create a minimal FileChange for testing
 #[allow(dead_code)]
@@ -42,6 +44,52 @@ pub fn make_renamed_file(old_path: &str, new_path: &str, similarity: u8) -> File
         is_binary: false,
         old_path: Some(PathBuf::from(old_path)),
         rename_similarity: Some(similarity),
+    }
+}
+
+/// Create a minimal `CodeSymbol` for testing, with `line: 1, end_line: 10`.
+///
+/// For tests that need the symbol to sit at a specific line range (e.g. to
+/// exercise hunk-to-span mapping), use [`make_symbol_at`] instead.
+#[allow(dead_code)]
+pub fn make_symbol(
+    name: &str,
+    kind: SymbolKind,
+    file: &str,
+    is_public: bool,
+    is_added: bool,
+) -> CodeSymbol {
+    make_symbol_at(name, kind, file, is_public, is_added, 1, 10)
+}
+
+/// Create a minimal `CodeSymbol` at an arbitrary line range.
+///
+/// Prefer this variant when a test needs to pin the symbol to specific
+/// `line` / `end_line` positions (for example, to line up with a manually
+/// crafted diff hunk). For the common case where positions are irrelevant,
+/// [`make_symbol`] uses the defaults `line: 1, end_line: 10`.
+#[allow(dead_code)]
+pub fn make_symbol_at(
+    name: &str,
+    kind: SymbolKind,
+    file: &str,
+    is_public: bool,
+    is_added: bool,
+    line: usize,
+    end_line: usize,
+) -> CodeSymbol {
+    CodeSymbol {
+        kind,
+        name: name.to_string(),
+        file: PathBuf::from(file),
+        line,
+        end_line,
+        is_public,
+        is_added,
+        is_whitespace_only: None,
+        span_change_kind: None,
+        signature: None,
+        parent_scope: None,
     }
 }
 

--- a/tests/splitter.rs
+++ b/tests/splitter.rs
@@ -6,33 +6,9 @@ mod helpers;
 
 use std::path::PathBuf;
 
-use commitbee::domain::{ChangeStatus, CodeSymbol, SymbolKind};
+use commitbee::domain::{ChangeStatus, SymbolKind};
 use commitbee::services::splitter::{CommitSplitter, SplitSuggestion};
-use helpers::{make_file_change, make_staged_changes};
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-fn make_symbol(
-    name: &str,
-    kind: SymbolKind,
-    file: &str,
-    is_public: bool,
-    is_added: bool,
-) -> CodeSymbol {
-    CodeSymbol {
-        kind,
-        name: name.to_string(),
-        file: PathBuf::from(file),
-        line: 1,
-        end_line: 10,
-        is_public,
-        is_added,
-        is_whitespace_only: None,
-        span_change_kind: None,
-        signature: None,
-        parent_scope: None,
-    }
-}
+use helpers::{make_file_change, make_staged_changes, make_symbol};
 
 // ─── Split detection tests ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

test: parametrise make_symbol helper by line range.

## Audit context

Closes audit entry D-040 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.