### PR TITLE
D-047: test(fuzz): signature extraction fuzzers for non-Rust languages

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -388,7 +388,6 @@ dependencies = [
  "gix",
  "globset",
  "indicatif",
- "keyring",
  "miette",
  "rayon",
  "regex",
@@ -1945,21 +1944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "byteorder",
- "linux-keyutils",
- "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,16 +1981,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
-dependencies = [
- "bitflags",
- "libc",
 ]
 
 [[package]]
@@ -2732,7 +2706,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -2760,7 +2734,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -2822,19 +2796,6 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,7 +13,18 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-commitbee = { path = "..", features = ["lang-rust"] }
+commitbee = { path = "..", default-features = false, features = [
+  "lang-rust",
+  "lang-typescript",
+  "lang-javascript",
+  "lang-python",
+  "lang-go",
+  "lang-java",
+  "lang-c",
+  "lang-cpp",
+  "lang-ruby",
+  "lang-csharp",
+] }
 
 [[bin]]
 name = "fuzz_sanitizer"
@@ -33,6 +44,11 @@ doc = false
 [[bin]]
 name = "fuzz_signature"
 path = "fuzz_targets/fuzz_signature.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_signature_multilang"
+path = "fuzz_targets/fuzz_signature_multilang.rs"
 doc = false
 
 [[bin]]

--- a/fuzz/fuzz_targets/fuzz_signature_multilang.rs
+++ b/fuzz/fuzz_targets/fuzz_signature_multilang.rs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 Sephyi <me@sephy.io>
+//
+// SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Commercial
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+// Dispatches the remaining input to a language-specific signature extractor
+// based on the first byte (`data[0] % 10`). Each `extract_*_signature`
+// function must never panic on any input — this fuzzer only asserts that.
+//
+// Language map (matches CommitBee's supported grammars):
+//   0 -> Rust
+//   1 -> TypeScript
+//   2 -> JavaScript
+//   3 -> Python
+//   4 -> Go
+//   5 -> Java
+//   6 -> C
+//   7 -> C++
+//   8 -> Ruby
+//   9 -> C#
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+    let selector = data[0] % 10;
+    let Ok(source) = std::str::from_utf8(&data[1..]) else {
+        return;
+    };
+    match selector {
+        0 => {
+            let _ = commitbee::extract_rust_signature(source);
+        }
+        1 => {
+            let _ = commitbee::extract_typescript_signature(source);
+        }
+        2 => {
+            let _ = commitbee::extract_javascript_signature(source);
+        }
+        3 => {
+            let _ = commitbee::extract_python_signature(source);
+        }
+        4 => {
+            let _ = commitbee::extract_go_signature(source);
+        }
+        5 => {
+            let _ = commitbee::extract_java_signature(source);
+        }
+        6 => {
+            let _ = commitbee::extract_c_signature(source);
+        }
+        7 => {
+            let _ = commitbee::extract_cpp_signature(source);
+        }
+        8 => {
+            let _ = commitbee::extract_ruby_signature(source);
+        }
+        9 => {
+            let _ = commitbee::extract_csharp_signature(source);
+        }
+        _ => unreachable!("selector is `% 10`"),
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_signature_multilang.rs
+++ b/fuzz/fuzz_targets/fuzz_signature_multilang.rs
@@ -26,39 +26,37 @@ fuzz_target!(|data: &[u8]| {
         return;
     }
     let selector = data[0] % 10;
-    let Ok(source) = std::str::from_utf8(&data[1..]) else {
-        return;
-    };
+    let source = String::from_utf8_lossy(&data[1..]);
     match selector {
         0 => {
-            let _ = commitbee::extract_rust_signature(source);
+            let _ = commitbee::extract_rust_signature(source.as_ref());
         }
         1 => {
-            let _ = commitbee::extract_typescript_signature(source);
+            let _ = commitbee::extract_typescript_signature(source.as_ref());
         }
         2 => {
-            let _ = commitbee::extract_javascript_signature(source);
+            let _ = commitbee::extract_javascript_signature(source.as_ref());
         }
         3 => {
-            let _ = commitbee::extract_python_signature(source);
+            let _ = commitbee::extract_python_signature(source.as_ref());
         }
         4 => {
-            let _ = commitbee::extract_go_signature(source);
+            let _ = commitbee::extract_go_signature(source.as_ref());
         }
         5 => {
-            let _ = commitbee::extract_java_signature(source);
+            let _ = commitbee::extract_java_signature(source.as_ref());
         }
         6 => {
-            let _ = commitbee::extract_c_signature(source);
+            let _ = commitbee::extract_c_signature(source.as_ref());
         }
         7 => {
-            let _ = commitbee::extract_cpp_signature(source);
+            let _ = commitbee::extract_cpp_signature(source.as_ref());
         }
         8 => {
-            let _ = commitbee::extract_ruby_signature(source);
+            let _ = commitbee::extract_ruby_signature(source.as_ref());
         }
         9 => {
-            let _ = commitbee::extract_csharp_signature(source);
+            let _ = commitbee::extract_csharp_signature(source.as_ref());
         }
         _ => unreachable!("selector is `% 10`"),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,24 +56,80 @@ pub fn parse_diff_hunks(diff: &str) -> Vec<services::analyzer::DiffHunk> {
     services::analyzer::DiffHunk::parse_from_diff(diff)
 }
 
-/// Extract signature from Rust source code for fuzz target access.
+/// Extract signature from source code using the given tree-sitter language.
 ///
-/// Parses the source with tree-sitter Rust, finds the first top-level definition,
-/// and extracts its signature. Must never panic on any input.
-#[cfg(feature = "lang-rust")]
-pub fn extract_rust_signature(source: &str) -> Option<String> {
+/// Parses the source, finds the first top-level definition, and extracts its
+/// signature. Must never panic on any input.
+fn extract_signature_for_language(source: &str, language: tree_sitter::Language) -> Option<String> {
     use tree_sitter::Parser;
     let mut parser = Parser::new();
-    if parser
-        .set_language(&tree_sitter_rust::LANGUAGE.into())
-        .is_err()
-    {
+    if parser.set_language(&language).is_err() {
         return None;
     }
     let tree = parser.parse(source, None)?;
     let root = tree.root_node();
     let first_child = root.child(0)?;
     services::analyzer::AnalyzerService::extract_signature(first_child, source)
+}
+
+/// Extract signature from Rust source code for fuzz target access.
+#[cfg(feature = "lang-rust")]
+pub fn extract_rust_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_rust::LANGUAGE.into())
+}
+
+/// Extract signature from TypeScript source code for fuzz target access.
+#[cfg(feature = "lang-typescript")]
+pub fn extract_typescript_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+}
+
+/// Extract signature from JavaScript source code for fuzz target access.
+#[cfg(feature = "lang-javascript")]
+pub fn extract_javascript_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_javascript::LANGUAGE.into())
+}
+
+/// Extract signature from Python source code for fuzz target access.
+#[cfg(feature = "lang-python")]
+pub fn extract_python_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_python::LANGUAGE.into())
+}
+
+/// Extract signature from Go source code for fuzz target access.
+#[cfg(feature = "lang-go")]
+pub fn extract_go_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_go::LANGUAGE.into())
+}
+
+/// Extract signature from Java source code for fuzz target access.
+#[cfg(feature = "lang-java")]
+pub fn extract_java_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_java::LANGUAGE.into())
+}
+
+/// Extract signature from C source code for fuzz target access.
+#[cfg(feature = "lang-c")]
+pub fn extract_c_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_c::LANGUAGE.into())
+}
+
+/// Extract signature from C++ source code for fuzz target access.
+#[cfg(feature = "lang-cpp")]
+pub fn extract_cpp_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_cpp::LANGUAGE.into())
+}
+
+/// Extract signature from Ruby source code for fuzz target access.
+#[cfg(feature = "lang-ruby")]
+pub fn extract_ruby_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_ruby::LANGUAGE.into())
+}
+
+/// Extract signature from C# source code for fuzz target access.
+#[cfg(feature = "lang-csharp")]
+pub fn extract_csharp_signature(source: &str) -> Option<String> {
+    extract_signature_for_language(source, tree_sitter_c_sharp::LANGUAGE.into())
 }
 
 /// Classify whether a diff span contains whitespace-only changes for fuzz target access.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,18 @@ pub fn parse_diff_hunks(diff: &str) -> Vec<services::analyzer::DiffHunk> {
 ///
 /// Parses the source, finds the first top-level definition, and extracts its
 /// signature. Must never panic on any input.
+#[cfg(any(
+    feature = "lang-rust",
+    feature = "lang-typescript",
+    feature = "lang-javascript",
+    feature = "lang-python",
+    feature = "lang-go",
+    feature = "lang-java",
+    feature = "lang-c",
+    feature = "lang-cpp",
+    feature = "lang-ruby",
+    feature = "lang-csharp",
+))]
 fn extract_signature_for_language(source: &str, language: tree_sitter::Language) -> Option<String> {
     use tree_sitter::Parser;
     let mut parser = Parser::new();


### PR DESCRIPTION
## Summary

test(fuzz): signature extraction fuzzers for non-Rust languages.

## Audit context

Closes audit entry D-047 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.