### PR TITLE
F-011: refactor(services): replace byte indexing with strip_prefix

### DIFF
--- a/src/services/context.rs
+++ b/src/services/context.rs
@@ -995,21 +995,20 @@ impl ContextBuilder {
                     continue;
                 }
                 // Detect added/removed import lines
-                if (line.starts_with('+') && Self::is_import_line(&line[1..]))
-                    || (line.starts_with('-') && Self::is_import_line(&line[1..]))
-                {
-                    let action = if line.starts_with('+') {
-                        "added"
-                    } else {
-                        "removed"
-                    };
+                let (action, content) = if let Some(rest) = line.strip_prefix('+') {
+                    ("added", rest)
+                } else if let Some(rest) = line.strip_prefix('-') {
+                    ("removed", rest)
+                } else {
+                    continue;
+                };
+                if Self::is_import_line(content) {
                     let stem = file
                         .path
                         .file_stem()
                         .and_then(|s| s.to_str())
                         .unwrap_or("?");
-                    let content = line[1..].trim();
-                    imports.push(format!("{}: {} {}", stem, action, content));
+                    imports.push(format!("{}: {} {}", stem, action, content.trim()));
                 }
             }
         }
@@ -1067,11 +1066,13 @@ impl ContextBuilder {
             let filename = file.path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
             for line in file.diff.lines() {
-                if !line.starts_with('+') || line.starts_with("+++") {
+                if line.starts_with("+++") {
                     continue;
                 }
+                let Some(content) = line.strip_prefix('+') else {
+                    continue;
+                };
                 total_added += 1;
-                let content = &line[1..];
                 let trimmed = content.trim();
 
                 // Error handling patterns
@@ -1207,13 +1208,17 @@ impl ContextBuilder {
             let name = file.path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
             for line in file.diff.lines() {
-                let is_removed = line.starts_with('-') && !line.starts_with("---");
-                let is_added = line.starts_with('+') && !line.starts_with("+++");
-                let content = if is_removed || is_added {
-                    &line[1..]
+                if line.starts_with("+++") || line.starts_with("---") {
+                    continue;
+                }
+                let (is_added, content) = if let Some(rest) = line.strip_prefix('+') {
+                    (true, rest)
+                } else if let Some(rest) = line.strip_prefix('-') {
+                    (false, rest)
                 } else {
                     continue;
                 };
+                let is_removed = !is_added;
 
                 match name {
                     "Cargo.toml" => {

--- a/src/services/safety.rs
+++ b/src/services/safety.rs
@@ -314,8 +314,9 @@ pub fn scan_full_diff_with_patterns(
         }
 
         // Only check added lines
-        if line.starts_with('+') && !line.starts_with("+++") {
-            let content = &line[1..];
+        if !line.starts_with("+++")
+            && let Some(content) = line.strip_prefix('+')
+        {
             for pat in patterns {
                 if pat.regex.is_match(content) {
                     found.push(SecretMatch {

--- a/src/services/splitter.rs
+++ b/src/services/splitter.rs
@@ -197,13 +197,13 @@ impl CommitSplitter {
         let mut indent_only_changes = 0usize;
         let added_lines: Vec<&str> = lines
             .iter()
-            .filter(|l| l.starts_with('+') && !l.starts_with("+++"))
-            .map(|l| &l[1..])
+            .filter(|l| !l.starts_with("+++"))
+            .filter_map(|l| l.strip_prefix('+'))
             .collect();
         let removed_lines: Vec<&str> = lines
             .iter()
-            .filter(|l| l.starts_with('-') && !l.starts_with("---"))
-            .map(|l| &l[1..])
+            .filter(|l| !l.starts_with("---"))
+            .filter_map(|l| l.strip_prefix('-'))
             .collect();
 
         for added_line in &added_lines {


### PR DESCRIPTION
## Summary

refactor(services): replace byte indexing with strip_prefix.

## Audit context

Closes audit entry F-011 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.