### PR TITLE
F-013: feat(observability): tracing spans on pipeline functions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -98,6 +98,10 @@ impl App {
         self.generate_commit().await
     }
 
+    #[tracing::instrument(
+        skip_all,
+        fields(provider = %self.config.provider, model = %self.config.model)
+    )]
     async fn generate_commit(&mut self) -> Result<()> {
         if self.cancel_token.is_cancelled() {
             return Err(Error::Cancelled);

--- a/src/services/analyzer.rs
+++ b/src/services/analyzer.rs
@@ -139,6 +139,7 @@ impl AnalyzerService {
 
     /// Extract symbols from file changes using full file content + hunk mapping.
     /// Uses rayon to parse files in parallel across CPU cores.
+    #[tracing::instrument(skip_all, fields(file_count = changes.len()))]
     pub fn extract_symbols(
         &self,
         changes: &[FileChange],

--- a/src/services/context.rs
+++ b/src/services/context.rs
@@ -36,6 +36,10 @@ const SKIP_CONTENT_FILES: &[&str] = &[
 pub struct ContextBuilder;
 
 impl ContextBuilder {
+    #[tracing::instrument(
+        skip_all,
+        fields(symbols = symbols.len(), diffs = diffs.len(), files = changes.files.len())
+    )]
     pub fn build(
         changes: &StagedChanges,
         symbols: &[CodeSymbol],


### PR DESCRIPTION
## Summary

feat(observability): tracing spans on pipeline functions.

## Audit context

Closes audit entry F-013 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.