### PR TITLE
F-017: ci: add cargo-deny license/advisory enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: fsfe/reuse-action@v4
+
+  deny:
+    name: Cargo Deny
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          arguments: --all-features

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Sephyi <me@sephy.io>
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Commercial
+
+# cargo-deny configuration for CommitBee.
+# Enforces PRD SR-005 (license / advisory / source policy) across the
+# dependency graph. Tuned for cargo-deny 0.19+.
+
+[graph]
+# Check all Tier-1 targets so platform-specific deps (e.g. security-framework
+# on macOS, winapi on Windows) don't sneak unreviewed licenses in.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = true
+
+[advisories]
+version = 2
+# Yanked crates are treated as advisories — refuse to ship them.
+yanked = "deny"
+# Start with an empty ignore list. Any accepted advisory must be added here
+# explicitly, with a link to the accompanying triage note.
+ignore = []
+
+[licenses]
+version = 2
+# Allow-list curated for the current dependency tree. Every entry is an SPDX
+# identifier. Add new ones only after reviewing the crate's license text.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "BSL-1.0",
+]
+confidence-threshold = 0.8
+
+[[licenses.exceptions]]
+# The root crate is dual-licensed (AGPL-3.0-only OR LicenseRef-Commercial).
+# cargo-deny doesn't resolve LicenseRef- identifiers against the allow-list,
+# so grant the root crate an explicit exception.
+name = "commitbee"
+allow = ["AGPL-3.0-only", "LicenseRef-Commercial"]
+
+[bans]
+# Duplicate versions are common in transitive deps (e.g. hashbrown 0.14/0.15).
+# Warn for visibility but don't fail CI — tighten later once the tree stabilises.
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+# Explicitly ban crates we don't want creeping in via transitive deps.
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

ci: add cargo-deny license/advisory enforcement.

## Audit context

Closes audit entry F-017 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.