### PR TITLE
F-018: chore: add clippy.toml with disallowed-methods / disallowed-macros

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Sephyi <me@sephy.io>
+#
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Commercial
+
+# Minimal, pragmatic clippy config to catch common anti-patterns at lint time.
+#
+# Keep this file small. Each rule should have a clear justification in its
+# `reason` so reviewers understand why the flagged call was blocked.
+
+# Disallow sync `std::process::Command` — the async pipeline must not block the
+# tokio runtime. Use `tokio::process::Command` or wrap in
+# `tokio::task::spawn_blocking` at async call-sites. Synchronous contexts
+# (integration tests, CLI bootstrap before the runtime starts) may allow this
+# lint locally with `#[allow(clippy::disallowed_methods)]` and a comment.
+disallowed-methods = [
+    { path = "std::process::Command::new", reason = "prefer tokio::process::Command or spawn_blocking in async contexts" },
+]
+
+# Disallow the `dbg!` macro — leftover debug scaffolding should never ship.
+# Use `tracing::{debug,trace}` for durable diagnostics.
+disallowed-macros = [
+    { path = "std::dbg", reason = "leftover debug scaffolding; remove before committing" },
+]

--- a/src/app.rs
+++ b/src/app.rs
@@ -990,6 +990,11 @@ impl App {
         // Verify we're in a git repo first
         let _git = GitService::discover()?;
 
+        // `hook_dir` is called from a synchronous `handle_hook` path (CLI
+        // bootstrap, no tokio runtime live yet). F-002 will migrate the hook /
+        // clipboard paths off sync `Command`; until then, allow the lint here
+        // so the new clippy.toml rule doesn't block unrelated PRs.
+        #[allow(clippy::disallowed_methods)]
         let output = std::process::Command::new("git")
             .args(["rev-parse", "--git-dir"])
             .output()?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -990,14 +990,17 @@ impl App {
         // Verify we're in a git repo first
         let _git = GitService::discover()?;
 
-        // `hook_dir` is called from a synchronous `handle_hook` path (CLI
-        // bootstrap, no tokio runtime live yet). F-002 will migrate the hook /
-        // clipboard paths off sync `Command`; until then, allow the lint here
-        // so the new clippy.toml rule doesn't block unrelated PRs.
-        #[allow(clippy::disallowed_methods)]
-        let output = std::process::Command::new("git")
-            .args(["rev-parse", "--git-dir"])
-            .output()?;
+        let output = if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::task::block_in_place(|| {
+                std::process::Command::new("git")
+                    .args(["rev-parse", "--git-dir"])
+                    .output()
+            })?
+        } else {
+            std::process::Command::new("git")
+                .args(["rev-parse", "--git-dir"])
+                .output()?
+        };
 
         if !output.status.success() {
             return Err(Error::Git("Cannot find .git directory".into()));

--- a/src/app.rs
+++ b/src/app.rs
@@ -990,17 +990,16 @@ impl App {
         // Verify we're in a git repo first
         let _git = GitService::discover()?;
 
-        let output = if tokio::runtime::Handle::try_current().is_ok() {
-            tokio::task::block_in_place(|| {
-                std::process::Command::new("git")
-                    .args(["rev-parse", "--git-dir"])
-                    .output()
-            })?
-        } else {
-            std::process::Command::new("git")
-                .args(["rev-parse", "--git-dir"])
-                .output()?
-        };
+        // `hook_dir` runs under the Tokio runtime (`main` is `#[tokio::main]`
+        // and hook commands reach here via `app.run().await`), so this
+        // `std::process::Command` can block a worker thread. F-002 will
+        // migrate the hook / clipboard paths to `tokio::process::Command`;
+        // until then, allow the lint locally so the new clippy.toml rule
+        // does not block unrelated PRs.
+        #[allow(clippy::disallowed_methods)]
+        let output = std::process::Command::new("git")
+            .args(["rev-parse", "--git-dir"])
+            .output()?;
 
         if !output.status.success() {
             return Err(Error::Git("Cannot find .git directory".into()));

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Commercial
 
+// Integration tests are synchronous and legitimately use `std::process::Command`
+// to build git fixtures in tempdirs; the `disallowed_methods` rule in
+// clippy.toml targets async-context misuse, which does not apply here.
+#![allow(clippy::disallowed_methods)]
+
 use commitbee::services::history::{HistoryContext, HistoryService};
 
 // ─── Subject Analysis (Pure Functions) ───────────────────────────────────────

--- a/tests/history.rs
+++ b/tests/history.rs
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Commercial
 
-// Integration tests are synchronous and legitimately use `std::process::Command`
-// to build git fixtures in tempdirs; the `disallowed_methods` rule in
-// clippy.toml targets async-context misuse, which does not apply here.
-#![allow(clippy::disallowed_methods)]
+// Keep `clippy::disallowed_methods` enabled for this file. If a synchronous
+// helper needs `std::process::Command` to build git fixtures in a tempdir,
+// allow it narrowly at that specific helper or call site with a short
+// justification rather than silencing the lint for async tests as well.
 
 use commitbee::services::history::{HistoryContext, HistoryService};
 

--- a/tests/porcelain.rs
+++ b/tests/porcelain.rs
@@ -23,6 +23,11 @@
 //! deferred to a follow-up — it requires the full pipeline setup and belongs
 //! in its own test file.
 
+// Integration tests are synchronous and legitimately use `std::process::Command`
+// to shell out to `git` / the `commitbee` binary; the `disallowed_methods` rule
+// in clippy.toml targets async-context misuse, which does not apply here.
+#![allow(clippy::disallowed_methods)]
+
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};


### PR DESCRIPTION
## Summary

chore: add clippy.toml with disallowed-methods / disallowed-macros.

## Audit context

Closes audit entry F-018 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.