### PR TITLE
F-019: docs(cli): document --allow-secrets risk in help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,13 +25,17 @@ pub struct Cli {
     #[arg(long)]
     pub dry_run: bool,
 
-    /// Allow committing even when potential secrets are detected in staged changes.
+    /// Allow proceeding after potential secrets are detected in staged changes.
     ///
-    /// DANGER: This disables the secret-scan block, meaning any API keys,
-    /// credentials, or tokens present in the staged diff will be sent to the
-    /// configured LLM provider as part of the prompt. Only use this flag when
-    /// you have manually audited the diff and are certain no real credentials
-    /// are present (e.g., test fixtures with obviously fake tokens).
+    /// ⚠ DANGER: Secrets are still scanned for. This flag does not bypass
+    /// detection; it only allows an interactive confirmation to continue after
+    /// secrets are found. In non-interactive modes (for example --yes,
+    /// --porcelain, or piped stdin), commitbee still fails closed instead of
+    /// proceeding. If you do confirm, any API keys, credentials, or tokens
+    /// present in the staged diff will be sent to the configured LLM provider
+    /// as part of the prompt. Only use this flag when you have manually
+    /// audited the diff and are certain no real credentials are present
+    /// (e.g., test fixtures with obviously fake tokens).
     #[arg(long)]
     pub allow_secrets: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,13 @@ pub struct Cli {
     #[arg(long)]
     pub dry_run: bool,
 
-    /// Allow committing with detected secrets (local only)
+    /// Allow committing even when potential secrets are detected in staged changes.
+    ///
+    /// ⚠ DANGER: This disables the secret-scan block, meaning any API keys,
+    /// credentials, or tokens present in the staged diff will be sent to the
+    /// configured LLM provider as part of the prompt. Only use this flag when
+    /// you have manually audited the diff and are certain no real credentials
+    /// are present (e.g., test fixtures with obviously fake tokens).
     #[arg(long)]
     pub allow_secrets: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Cli {
 
     /// Allow committing even when potential secrets are detected in staged changes.
     ///
-    /// ⚠ DANGER: This disables the secret-scan block, meaning any API keys,
+    /// DANGER: This disables the secret-scan block, meaning any API keys,
     /// credentials, or tokens present in the staged diff will be sent to the
     /// configured LLM provider as part of the prompt. Only use this flag when
     /// you have manually audited the diff and are certain no real credentials


### PR DESCRIPTION
## Summary

docs(cli): document --allow-secrets risk in help text.

## Audit context

Closes audit entry F-019 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.