### PR TITLE
F-025: fix(app): log Ctrl+C handler install failures

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -86,7 +86,10 @@ impl App {
         // Setup Ctrl+C handler with CancellationToken
         let cancel = self.cancel_token.clone();
         tokio::spawn(async move {
-            signal::ctrl_c().await.ok();
+            if let Err(e) = signal::ctrl_c().await {
+                warn!(error = %e, "failed to install Ctrl+C handler");
+                return;
+            }
             cancel.cancel();
         });
 


### PR DESCRIPTION
## Summary

fix(app): log Ctrl+C handler install failures.

## Audit context

Closes audit entry F-025 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.