### PR TITLE
F-028: refactor: extract binary to lib.rs and enforce #![forbid(unsafe_code)]

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,20 +2,11 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Commercial
 
+#![forbid(unsafe_code)]
+
 use clap::Parser;
+use commitbee::{App, Cli, error};
 use tracing_subscriber::EnvFilter;
-
-mod app;
-mod cli;
-mod config;
-mod domain;
-mod error;
-#[cfg(feature = "eval")]
-mod eval;
-mod services;
-
-use app::App;
-use cli::Cli;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
## Summary

refactor: extract binary to lib.rs and enforce #![forbid(unsafe_code)].

## Audit context

Closes audit entry F-028 from #3.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets`

> Note: one pre-existing test `porcelain_exits_within_timeout_with_no_staged_changes` is a known macOS cold-start flake that reproduces on unmodified `development` — unrelated to this change.